### PR TITLE
chore: whitelist files to publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.nyc_output
-coverage
-dkim-public.key
-dkim-private.key
-mx1.forwardemail.net.ca
-mx1.forwardemail.net.cert
-mx1.forwardemail.net.csr
-mx1.forwardemail.net.key

--- a/package.json
+++ b/package.json
@@ -112,6 +112,12 @@
     }
   },
   "main": "index.js",
+  "files": [
+    "blacklist.json",
+    "ecosystem.json",
+    "index.js",
+    "message-splitter.js"
+  ],
   "prettier": {
     "singleQuote": true,
     "bracketSpacing": true,


### PR DESCRIPTION
github pages files are not required in npm.

```
$ npm publish --dry-run
npm notice 
npm notice 📦  forward-email@2.0.1
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE            
npm notice 28.9kB index.js           
npm notice 4.5kB  message-splitter.js
npm notice 21B    blacklist.json     
npm notice 1.0kB  ecosystem.json     
npm notice 3.6kB  package.json       
npm notice 33.1kB README.md
```