### PR TITLE
Include "executable files" in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,10 @@
     "helpers/**/*",
     ".env.defaults",
     ".env.schema",
-    "index.js"
+    "index.js",
+    "app.js",
+    "proxy.js",
+    "ecosystem.json"
   ],
   "homepage": "http://forwardemail.net",
   "husky": {


### PR DESCRIPTION
I'd like to add your application to [nixpkgs](https://github.com/NixOS/nixpkgs), but it requires the files needed to actually run the server to be present.