### PR TITLE
1st attempt at adding regex matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -2487,7 +2487,7 @@ class ForwardEmail {
       // convert addresses to lowercase
       const lowerCaseAddress = element.toLowerCase();
       if (
-        (lowerCaseAddress.includes(':') ||
+        (lowerCaseAddress.substring(lowerCaseAddress.lastIndexOf('/').includes(':')) ||
           lowerCaseAddress.indexOf('!') === 0) &&
         !validator.isURL(element, this.config.isURLOptions)
       ) {
@@ -2527,7 +2527,14 @@ class ForwardEmail {
             `${lowerCaseAddress} domain of ${domain} has an invalid "${this.config.recordPrefix}" TXT record due to an invalid email address of "${element}"`
           );
 
-        if (_.isString(addr[0]) && username === addr[0].toLowerCase()) {
+        if (addr[0].startsWith('/') && addr[0].endsWith('/')) {
+          let regex = RegExp(`^${addr[0].slice(1, -1)}$`, 'i');
+          if (regex.test(username)) {
+            if (validator.isURL(addr[1], this.config.isURLOptions))
+              forwardingAddresses.push(addr[1]);
+            else forwardingAddresses.push(addr[1].toLowerCase());
+          }
+        } else if (_.isString(addr[0]) && username === addr[0].toLowerCase()) {
           if (validator.isURL(addr[1], this.config.isURLOptions))
             forwardingAddresses.push(addr[1]);
           else forwardingAddresses.push(addr[1].toLowerCase());


### PR DESCRIPTION
I had a lot of difficulty getting this repo to run successfully on my local (Windows) machine so **I am sure this is not complete -- it is intended to be a starting point** for implementing a regex match feature.

Very simply: instead of `forward-email=hello:user@gmail.com` you can use `forward-email=/h.*o/:user@gmail.com`

The key is to wrap the regex pattern by slashes in the DNS entry (similar to how you'd define a regex in code). However no flags are allowed, so `/h.*o/ig` would fail. The code automatically applies the `i` (ignore case) flag.

The code looks for a complete match only: `/e.*o/` will not match `hello` even though a substring does match. The user does not have to start the regex with `^` nor end it with `$`, this is done via code.