### PR TITLE
Add header to forwarded email describing original address

### DIFF
--- a/index.js
+++ b/index.js
@@ -1861,6 +1861,9 @@ class ForwardEmail {
                 this.config.simpleParser
               );
 
+              // Set header describing original address
+              mail.headers.set("X-ForwardEmail-User", to.address)
+
               if (this.client)
                 await this.client.set(
                   key,


### PR DESCRIPTION
*Note that I haven't been able to test this yet, but I would very much appreciate some feedback on the idea and implementation*

I'd like to be able to process mail further on my own server after it passes through ForwardEmail, and the To:/Cc:/Bcc: headers are unreliable for finding the original address the mail was sent to. This PR would add a header to mail describing the original email that ForwardEmail processed.
